### PR TITLE
Maximum of 5 code suggestions. Codensed report.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,11 @@ import {
   createFetchRequest,
 } from "./lib/languageToolClient.js";
 import { generateReport, reporters } from "./lib/report.js";
-import { ProgramOptions, LanguageToolResult } from "./lib/types.js";
+import {
+  ProgramOptions,
+  LanguageToolResult,
+  ReportStats,
+} from "./lib/types.js";
 import { convertMarkdownToAnnotated } from "./lib/markdownToAnnotated.js";
 import { getFilesFromPr } from "./lib/githubReporter.js";
 
@@ -72,12 +76,13 @@ async function run() {
   });
 
   const reporter = options.githubpr ? reporters.githubpr : reporters.markdown;
+  const stats = new ReportStats();
 
   for (const result of correlatedResults) {
-    await generateReport(result, reporter, options);
+    await generateReport(result, reporter, options, stats);
   }
 
   if (reporter.complete) {
-    await reporter.complete(correlatedResults, options);
+    await reporter.complete(options, stats);
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,12 @@ const parser = yargs(hideBin(process.argv))
       default: false,
       describe: "Only report issues on lines that are part of the PR's diff.",
     },
+    "max-suggestions": {
+      type: "number",
+      default: 5,
+      describe:
+        "Maximum number of PR suggestion comments to add to a PR. (Too many gets unwieldy.)",
+    },
     "custom-dict-file": {
       type: "string",
       default: "",
@@ -72,6 +78,6 @@ async function run() {
   }
 
   if (reporter.complete) {
-    await reporter.complete(options);
+    await reporter.complete(correlatedResults, options);
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ const parser = yargs(hideBin(process.argv))
       default: false,
       describe: "Only report issues on lines that are part of the PR's diff.",
     },
-    "max-suggestions": {
+    "max-pr-suggestions": {
       type: "number",
       default: 5,
       describe:

--- a/lib/githubReporter.ts
+++ b/lib/githubReporter.ts
@@ -119,7 +119,7 @@ async function addCommentToPr(
   options: ProgramOptions,
   stats: ReportStats
 ) {
-  if (stats.getCounter(PR_COMMENT_COUNTER) >= options["max-suggestions"]) {
+  if (stats.getCounter(PR_COMMENT_COUNTER) >= options["max-pr-suggestions"]) {
     prGeneralComment += markdownReporter.issue(item, options, stats);
     return;
   }

--- a/lib/markdownReporter.ts
+++ b/lib/markdownReporter.ts
@@ -9,28 +9,19 @@ export const markdownReporter: Reporter = {
   noIssues: (result: LanguageToolResult, options: ProgramOptions) => {
     return `- [X] **${result.path}** has no issues.\n\n`;
   },
-  issue: (
-    {
-      result,
-      line,
-      column,
-      message,
-      contextHighlighted,
-      contextPrefix,
-      contextPostfix,
-      replacements,
-    }: ReporterItem,
-    options: ProgramOptions
-  ) => {
+  issue: (item: ReporterItem, options: ProgramOptions) => {
     return (
-      `- [ ] **${result.path}** \`(${line},${column})\` - _${message}_\n\n` +
-      "  ```diff\n" +
-      `  - «${contextHighlighted}»\n` +
-      (replacements.length
-        ? `  + Possible replacements: «${replacements.join(", ")}»\n`
-        : "") +
-      `  # Context: «${contextPrefix}**${contextHighlighted}**${contextPostfix}»\n` +
-      "  ```\n\n"
+      `- [ ] **${item.result.path}** \`(${item.line},${item.column})\`\n${item.message} \`${item.contextHighlighted}\`` +
+      `\n\n   \`\`\`diff\n   - ${item.currentLine}\n` +
+      (item.suggestedLine
+        ? `   + ${item.suggestedLine}\n` +
+          (item.replacements.length > 1
+            ? "   ```\n   **Suggestion(s):** " + item.replacements.join(", ")
+            : "")
+        : item.match.rule.issueType === "misspelling"
+        ? "   ```\n   If this is code (like a variable name), try surrounding it with \\`backticks\\`."
+        : "   ```") +
+      "\n\n"
     );
   },
 };

--- a/lib/markdownReporter.ts
+++ b/lib/markdownReporter.ts
@@ -1,27 +1,40 @@
-import {
-  ProgramOptions,
-  LanguageToolResult,
-  Reporter,
-  ReporterItem,
-} from "./types.js";
+import { Reporter } from "./types.js";
+
+export const MARKDOWN_ITEM_COUNTER = "Markdown Items";
 
 export const markdownReporter: Reporter = {
-  noIssues: (result: LanguageToolResult, options: ProgramOptions) => {
+  noIssues: (result) => {
     return `- [X] **${result.path}** has no issues.\n\n`;
   },
-  issue: (item: ReporterItem, options: ProgramOptions) => {
-    return (
-      `- [ ] **${item.result.path}** \`(${item.line},${item.column})\`\n${item.message} \`${item.contextHighlighted}\`` +
-      `\n\n   \`\`\`diff\n   - ${item.currentLine}\n` +
-      (item.suggestedLine
-        ? `   + ${item.suggestedLine}\n` +
-          (item.replacements.length > 1
-            ? "   ```\n   **Suggestion(s):** " + item.replacements.join(", ")
-            : "")
-        : item.match.rule.issueType === "misspelling"
-        ? "   ```\n   If this is code (like a variable name), try surrounding it with \\`backticks\\`."
-        : "   ```") +
-      "\n\n"
-    );
+  issue: (item, options, stats) => {
+    const md: string[] = [];
+    md.push(`**${item.result.path}** \`(${item.line},${item.column})\``);
+    md.push(`${item.message} \`${item.contextHighlighted}\``);
+    md.push("");
+    md.push("```diff");
+    md.push(`- ${item.currentLine}`);
+    if (item.suggestedLine) {
+      md.push(`+ ${item.suggestedLine}`);
+      md.push("```");
+      if (item.replacements.length > 0) {
+        md.push(
+          "**Suggestion(s):** " +
+            item.replacements.map((r) => "`" + r + "`").join(", ")
+        );
+      }
+    } else {
+      md.push("```");
+      if (item.match.rule.issueType === "misspelling") {
+        md.push(
+          "If this is code (like a variable name), try surrounding it with \\`backticks\\`."
+        );
+      }
+    }
+    md.push("");
+    md.push("---");
+    md.push("");
+
+    stats.incrementCounter(MARKDOWN_ITEM_COUNTER);
+    return md.join("\n");
   },
 };

--- a/lib/markdownToAnnotated.ts
+++ b/lib/markdownToAnnotated.ts
@@ -1,17 +1,6 @@
 import * as builder from "annotatedtext-remark";
 
 const builderOptions = builder.defaults;
-const original_interpretmarkup = builder.defaults.interpretmarkup;
-builderOptions.interpretmarkup = (text = "") => {
-  const original = original_interpretmarkup(text);
-  if (!original) {
-    // interpret `foo` as: foo
-    if (/^\`([^\`].*?[^\`])\`$/gm.test(text)) {
-      return text.replace(/^\`([^\`].*?[^\`])\`$/gm, "$1");
-    }
-  }
-  return original;
-};
 
 export function convertMarkdownToAnnotated(markdownText: string) {
   return builder.build(markdownText, builderOptions);

--- a/lib/report.ts
+++ b/lib/report.ts
@@ -1,5 +1,5 @@
 import { location } from "vfile-location";
-import { ProgramOptions, LanguageToolResult } from "./types.js";
+import { ProgramOptions, LanguageToolResult, ReportStats } from "./types.js";
 import { githubReporter } from "./githubReporter.js";
 import { markdownReporter } from "./markdownReporter.js";
 
@@ -11,13 +11,14 @@ export const reporters = {
 export async function generateReport(
   result: LanguageToolResult,
   reporter = reporters.markdown,
-  options: ProgramOptions
+  options: ProgramOptions,
+  stats: ReportStats
 ) {
   const matches = result.matches;
   const matchesTotal = matches.length;
 
   if (!matchesTotal) {
-    process.stdout.write(reporter.noIssues(result, options));
+    process.stdout.write(reporter.noIssues(result, options, stats));
     return;
   }
 
@@ -84,7 +85,8 @@ export async function generateReport(
         currentLine,
         match,
       },
-      options
+      options,
+      stats
     );
 
     if (typeof reportedIssue === "string") {

--- a/lib/report.ts
+++ b/lib/report.ts
@@ -67,7 +67,6 @@ export async function generateReport(
       match.rule.issueType === "misspelling" &&
       options.customDict?.includes(contextHighlighted.toLowerCase())
     ) {
-      match.ignored = true;
       continue;
     }
 

--- a/lib/report.ts
+++ b/lib/report.ts
@@ -66,6 +66,7 @@ export async function generateReport(
       match.rule.issueType === "misspelling" &&
       options.customDict?.includes(contextHighlighted.toLowerCase())
     ) {
+      match.ignored = true;
       continue;
     }
 
@@ -80,6 +81,8 @@ export async function generateReport(
         contextPostfix,
         replacements,
         suggestedLine,
+        currentLine,
+        match,
       },
       options
     );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -87,11 +87,33 @@ export interface ReporterItem {
   currentLine: string;
   match: LanguageToolMatch;
 }
+
+export class ReportStats {
+  private counters: { [key: string]: number } = {};
+  incrementCounter(key: string): void {
+    this.counters[key] = this.getCounter(key) + 1;
+  }
+  getCounter(key: string): number {
+    return this.counters[key] ?? 0;
+  }
+  sumAllCounters(): number {
+    return Object.keys(this.counters).reduce(
+      (sum, key) => sum + this.getCounter(key),
+      0
+    );
+  }
+}
+
 export interface Reporter {
-  noIssues(result: LanguageToolResult, options: ProgramOptions): string;
-  issue(item: ReporterItem, options: ProgramOptions): string | Promise<void>;
-  complete?(
-    results: LanguageToolResult[],
-    options: ProgramOptions
-  ): Promise<void>;
+  noIssues(
+    result: LanguageToolResult,
+    options: ProgramOptions,
+    stats: ReportStats
+  ): string;
+  issue(
+    item: ReporterItem,
+    options: ProgramOptions,
+    stats: ReportStats
+  ): string | Promise<void>;
+  complete?(options: ProgramOptions, stats: ReportStats): Promise<void>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,7 @@ export interface ProgramOptions {
   githubpr: string;
   "pr-diff-only": boolean;
   "custom-dict-file": string;
+  "max-suggestions": number;
   customDict?: string[];
 }
 
@@ -66,6 +67,7 @@ export interface LanguageToolMatch {
   rule: LanguageToolRule;
   ignoreForIncompleteSentence: boolean;
   contextForSureMatch: number;
+  ignored?: boolean;
 }
 
 export interface LanguageToolResult extends LoadFileResponse {
@@ -82,9 +84,14 @@ export interface ReporterItem {
   contextPostfix: string;
   replacements: string[];
   suggestedLine: string;
+  currentLine: string;
+  match: LanguageToolMatch;
 }
 export interface Reporter {
   noIssues(result: LanguageToolResult, options: ProgramOptions): string;
   issue(item: ReporterItem, options: ProgramOptions): string | Promise<void>;
-  complete?(options: ProgramOptions): Promise<void>;
+  complete?(
+    results: LanguageToolResult[],
+    options: ProgramOptions
+  ): Promise<void>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,7 +67,6 @@ export interface LanguageToolMatch {
   rule: LanguageToolRule;
   ignoreForIncompleteSentence: boolean;
   contextForSureMatch: number;
-  ignored?: boolean;
 }
 
 export interface LanguageToolResult extends LoadFileResponse {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,7 @@ export interface ProgramOptions {
   githubpr: string;
   "pr-diff-only": boolean;
   "custom-dict-file": string;
-  "max-suggestions": number;
+  "max-pr-suggestions": number;
   customDict?: string[];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/languagetool-cli",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Run LanguageTool for linting Markdown files during CI",
   "keywords": [
     "languagetool",


### PR DESCRIPTION
<!-- Describe your Pull Request -->
A docs PR with additions of new Markdown files could generate dozens or more of issues. This was completely unwieldy for authors and reviewers when each one was represented as an individual PR review comment.

This PR introduces the `--max-pr-suggestions` parameter, which defaults to 5. After reaching 5 suggestions, it incorporates the rest of the issues into a single comment that is collapsed by default, but can be expanded by clicking on it. 

[View this PR for an example](https://github.com/twilio-internal/internal-product-docs/pull/32). I ran this version of the command on that PR using the following command line arguments:

```
--githubpr https://github.com/twilio-internal/internal-product-docs/pull/32 --pr-diff-only --max-pr-suggestions 5 --custom-dict-file ~/Projects/internal-product-docs/dicts/twilio_extended.txt
```

(run from a working directory of the branch corresponding with that PR)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
