### PR TITLE
Improve handling large number of results not part of diff

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import {
   ProgramOptions,
   LanguageToolResult,
   ReportStats,
+  FileWithDiffInfo,
 } from "./lib/types.js";
 import { convertMarkdownToAnnotated } from "./lib/markdownToAnnotated.js";
 import { getFilesFromPr } from "./lib/githubReporter.js";
@@ -53,7 +54,7 @@ async function run() {
   const options = (await parser.argv) as ProgramOptions;
   options.customDict = await loadCustomDict(options["custom-dict-file"]);
 
-  let filePathsToCheck = options._;
+  let filePathsToCheck: Array<string | FileWithDiffInfo> = options._;
   if (options.githubpr) {
     filePathsToCheck = [
       ...filePathsToCheck,

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -1,17 +1,23 @@
 import { readFile } from "fs/promises";
-import { LoadFileResponse } from "./types.js";
+import { LoadFileResponse, FileWithDiffInfo } from "./types.js";
 
-function loadFile(path: string): Promise<LoadFileResponse | null> {
+function loadFile(
+  pathItem: string | FileWithDiffInfo
+): Promise<LoadFileResponse | null> {
+  const path = typeof pathItem === "string" ? pathItem : pathItem.filename;
+  const changedLines =
+    typeof pathItem === "string" ? undefined : pathItem.changedLines;
+
   return new Promise((resolve) => {
     readFile(path, { encoding: "utf-8" })
       .then((contents) => {
-        resolve({ contents, path });
+        resolve({ contents, path, changedLines });
       })
       .catch(() => resolve(null));
   });
 }
 
-export async function loadFiles(paths: string[]) {
+export async function loadFiles(paths: Array<string | FileWithDiffInfo>) {
   const responses = await Promise.all(paths.map((path) => loadFile(path)));
   return responses
     .filter((response) => !!response)

--- a/lib/githubReporter.ts
+++ b/lib/githubReporter.ts
@@ -180,8 +180,6 @@ async function addCommentToPr(
     );
   }
 
-  // await snooze(1000);
-
   try {
     await octokit.rest.pulls.createReviewComment({
       owner: pr.owner,

--- a/lib/parseGitPatch.ts
+++ b/lib/parseGitPatch.ts
@@ -1,0 +1,53 @@
+export function getChangedLineNumbersFromPatch(patch: string): number[] {
+  const fileLinesRegex = /^@@ -([0-9]*),?\S* \+([0-9]*),?/;
+  const lineNumbersInDiff: number[] = [];
+
+  splitIntoParts(patch.split("\n"), "@@ ").forEach((lines) => {
+    const fileLinesLine = lines.shift() as string;
+    const matches = fileLinesLine.match(fileLinesRegex);
+    if (!matches) return [];
+
+    const [, a, b] = matches;
+
+    let nA = parseInt(a);
+    let nB = parseInt(b);
+
+    lines.forEach((line: string) => {
+      if (line.startsWith("+")) {
+        nA--;
+
+        lineNumbersInDiff.push(nB);
+      } else if (line.startsWith("-")) {
+        nB--;
+      }
+
+      nA++;
+      nB++;
+    });
+  });
+
+  return lineNumbersInDiff;
+}
+
+function splitIntoParts(lines: string[], separator: string) {
+  const parts: string[][] = [];
+  let currentPart: undefined | string[] = undefined;
+
+  lines.forEach((line) => {
+    if (line.startsWith(separator)) {
+      if (currentPart) {
+        parts.push(currentPart);
+      }
+
+      currentPart = [line];
+    } else if (currentPart) {
+      currentPart.push(line);
+    }
+  });
+
+  if (currentPart) {
+    parts.push(currentPart);
+  }
+
+  return parts;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,6 +27,7 @@ export interface LoadFileResponse {
   contents: string;
   path: string;
   annotatedText?: AnnotatedText;
+  changedLines?: number[];
 }
 
 export interface LanguageToolReplacement {
@@ -115,4 +116,9 @@ export interface Reporter {
     stats: ReportStats
   ): string | Promise<void>;
   complete?(options: ProgramOptions, stats: ReportStats): Promise<void>;
+}
+
+export interface FileWithDiffInfo {
+  filename: string;
+  changedLines: number[];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/languagetool-cli",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Run LanguageTool for linting Markdown files during CI",
   "keywords": [
     "languagetool",

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -10,7 +10,11 @@ const markdown2 = getMarkdownFixturePath("2");
 const markdown3 = getMarkdownFixturePath("3");
 
 test("loads three files", async () => {
-  const result = await loadFiles([markdown1, markdown2, markdown3]);
+  const result = await loadFiles([
+    markdown1,
+    markdown2,
+    { filename: markdown3, changedLines: [1, 2, 3] },
+  ]);
   expect(result.length).toEqual(3);
 
   expect(result[0].path).toEqual(markdown1);
@@ -30,6 +34,7 @@ test("loads three files", async () => {
     "# Manus signaque tradiderat sonus et Andraemon fraudes"
   );
   expect(result[2].annotatedText).toBeUndefined();
+  expect(result[2].changedLines).toEqual([1, 2, 3]);
 });
 
 test("loads one file, ignores bad path", async () => {

--- a/test/fixtures/patches/1.patch
+++ b/test/fixtures/patches/1.patch
@@ -1,0 +1,21 @@
+@@ -47,17 +47,13 @@ Short on time? Check out our [5-minute tutorial ⏱️](https://tutorial.docusau
+ 
+ ## Installation
+ 
+-Use the initialization cli to create your site:
++Use the initialization CLI to create your site:
+ 
+ ```bash
+-npm init docusaurus@latest [name] [template]
++npm init docusaurus@latest
+ ```
+ 
+-Example:
+-
+-```bash
+-npm init docusaurus@latest my-website classic
+-```
++[Read the docs](https://docusaurus.io/docs/installation) for any further information.
+ 
+ ## Contributing
+ 

--- a/test/fixtures/patches/2.patch
+++ b/test/fixtures/patches/2.patch
@@ -1,0 +1,22 @@
+@@ -7,11 +7,7 @@ sidebar_label: Pages
+ 
+ In this section, we will learn about creating pages in Docusaurus.
+ 
+-This is useful for creating **one-off standalone pages** like a showcase page, playground page, or support page.
+-
+-The functionality of pages is powered by `@docusaurus/plugin-content-pages`.
+-
+-You can use React components, or Markdown.
++The `@docusaurus/plugin-content-pages` plugin empowers you to create **one-off standalone pages** like a showcase page, playground page, or support page. You can use React components, or Markdown.
+ 
+ :::note
+ 
+@@ -69,7 +65,7 @@ You can also create TypeScript pages with the `.tsx` extension (`helloReact.tsx`
+ 
+ Create a file `/src/pages/helloMarkdown.md`:
+ 
+-```mdx title="/src/pages/helloMarkdown.md"
++```md title="/src/pages/helloMarkdown.md"
+ ---
+ title: my hello page title
+ description: my hello page description

--- a/test/fixtures/patches/3.patch
+++ b/test/fixtures/patches/3.patch
@@ -1,0 +1,17 @@
+@@ -257,14 +257,14 @@ If you put some HTML pages under the `static` folder, they will be copied to the
+ 
+ <BrowserWindow>
+ 
+-- <Link data-noBrokenLinkCheck="true" to="/pure-html">/pure-html</Link>
++- [/pure-html](/pure-html)
+ - [pathname:///pure-html](pathname:///pure-html)
+ 
+ </BrowserWindow>
+ 
+ :::tip
+ 
+-The first link will trigger a "broken links detected" check during the production build.
++The first link will **not** trigger a "broken links detected" check during the production build, because the respective file actually exists. Nevertheless, when you click on the link, a "page not found" will be displayed until you refresh.
+ 
+ :::
+ 

--- a/test/githubReporter.getFilesFromPr.test.ts
+++ b/test/githubReporter.getFilesFromPr.test.ts
@@ -47,7 +47,7 @@ test("invoke", async () => {
     .delete("/repos/dprothero/testing-ground/pulls/comments/840961847")
     .reply(204, "", prResponse.headers);
 
-  // Finally it will getch the list of files modified by the PR
+  // Finally it will fetch the list of files modified by the PR
   nock("https://api.github.com:443", { encodedQueryParams: true })
     .get("/repos/dprothero/testing-ground/pulls/1/files")
     .reply(200, prFiles.payload, prFiles.headers);
@@ -56,7 +56,10 @@ test("invoke", async () => {
     "https://github.com/dprothero/testing-ground/pull/1"
   );
 
-  expect(files).toEqual(["README.md", "README.mdx"]);
+  expect(files).toEqual([
+    { filename: "README.md", changedLines: [1, 2] },
+    { filename: "README.mdx", changedLines: [1, 2] },
+  ]);
   expect(nock.isDone()).toBeTruthy();
 });
 

--- a/test/parseGitPatch.test.ts
+++ b/test/parseGitPatch.test.ts
@@ -1,0 +1,36 @@
+import { suite } from "uvu";
+import expect from "expect";
+import { getChangedLineNumbersFromPatch } from "../lib/parseGitPatch.js";
+import { getPatchFixture } from "./testUtilities.js";
+
+const test = suite("getChangedLineNumbersFromPatch");
+
+test("basic patch parsing", () => {
+  const patch = getPatchFixture();
+  const results = getChangedLineNumbersFromPatch(patch);
+  expect(results).toEqual([50, 53, 56]);
+});
+
+test("patch with multiple sections", () => {
+  const patch = getPatchFixture("2");
+  const results = getChangedLineNumbersFromPatch(patch);
+  expect(results).toEqual([10, 68]);
+});
+
+test("patch with bulleted list", () => {
+  const patch = getPatchFixture("3");
+  const results = getChangedLineNumbersFromPatch(patch);
+  expect(results).toEqual([260, 267]);
+});
+
+test("blank input", () => {
+  const results = getChangedLineNumbersFromPatch("");
+  expect(results).toEqual([]);
+});
+
+test("invalid input", () => {
+  const results = getChangedLineNumbersFromPatch("@@ ");
+  expect(results).toEqual([]);
+});
+
+test.run();

--- a/test/testUtilities.ts
+++ b/test/testUtilities.ts
@@ -18,6 +18,16 @@ export function getMarkdownFixturePath(name: string = "1"): string {
   return path.resolve(__dirname, "fixtures", "markdown", name + ".md");
 }
 
+export function getPatchFixture(name: string = "1"): string {
+  const fullPath = path.resolve(
+    __dirname,
+    "fixtures",
+    "patches",
+    name + ".patch"
+  );
+  return fs.readFileSync(fullPath, { encoding: "utf8" });
+}
+
 export interface JSONFixture {
   payload: any;
   headers: string[];
@@ -70,6 +80,7 @@ export async function getFakeResult(): Promise<FakeResult> {
     path: "README.md",
     matches: [],
     annotatedText: undefined,
+    changedLines: [...markdown.contents.split("\n").keys()],
   };
 
   const fakeOptions = {


### PR DESCRIPTION
When there were a large number of LanguageTool results that weren't part of the diff on a PR, it was possible to run into GitHub's rate limiting. In investigating the issue it was also discovered that results that weren't part of the diff after we reached the maximum suggestions (review comments tied to a line number), they were all added to the general comment, even if `pr-diff-only` was `true`.

This PR adds a 1 second delay between review comment API calls (GitHub's suggestion).

However, this greatly slowed down the running of the tool when there were lots of results not part of the diff. Instead of relying on getting the error back from the GitHub API to tell us whether a change is part of the diff or not, we now determine that client-side and avoid the unnecessary API calls.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
