### PR TITLE
Fixed  incorrect $LT_URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ languagetool-cli sample.md > output.md
 If you would like to use a different URL for the LanguageTool service, set the `LT_URL` environment variable like so:
 
 ```sh
-export LT_URL="http://localhost:8081/v2/check"
+export LT_URL="http://localhost:8081/v2"
 ```


### PR DESCRIPTION
The example URL for `LT_URL` in the README.md does not work. The trailing `/check` needs to be removed.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
